### PR TITLE
Bugfix/bd opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 fish-bd
 =======
 
-**Quickly go back to a parent directory up in your current working directory tree.**  
+**Quickly go back to a parent directory up in your current working directory tree.**
 **Don't write 'cd ../../..' redundantly, use bd instead.**
 
-This is a fish implementation of [vigneshwaranr/bd](https://github.com/vigneshwaranr/bd) by Vigneshwaran Raveendran 
+This is a fish implementation of [vigneshwaranr/bd](https://github.com/vigneshwaranr/bd) by Vigneshwaran Raveendran
 
 
 
@@ -33,7 +33,7 @@ Example:
     # or
     > bd -i P
     # And you are now in /home/user/my/path/
-	
+
 Options:
     -c		Classic mode : goes back to the first directory named as the string
 	    		Set it as default using (set -gx BD_OPT 'classic')
@@ -41,7 +41,7 @@ Options:
     -s		Seems mode : goes back to the first directory containing string
     	    	Set it as default using (set -gx BD_OPT 'sensitive')
     -i		Case insensitive move (implies seems mode)
-    	    	Set it as default using (set -gx BD_OPT 'insensitive')    
+    	    	Set it as default using (set -gx BD_OPT 'insensitive')
     --help	Display this help text
 
     Option must be unique and the first argument due to shell limitation.
@@ -55,8 +55,8 @@ Installation
 Run `make install`. Assumes your fish config directory is `~/.config/fish`.
 
 #### Manual Install
-Copy `bd.fish` into the `/functions` directory off of your fish config root.  
-Copy `completions/bd.fish` into the `/completions` directory off of your fish 
+Copy `bd.fish` into the `/functions` directory off of your fish config root.
+Copy `completions/bd.fish` into the `/completions` directory off of your fish
 config root.
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Example:
 	
 Options:
     -c		Classic mode : goes back to the first directory named as the string
-	    		Set if default using (set -gx BD_OPT 'classic')
+	    		Set it as default using (set -gx BD_OPT 'classic')
 	    		Default mode when BD_OPT or CLI options are specified
     -s		Seems mode : goes back to the first directory containing string
     	    	Set it as default using (set -gx BD_OPT 'sensitive')

--- a/bd.fish
+++ b/bd.fish
@@ -27,7 +27,7 @@ Example:
     # or
     > bd -i P
     # And you are now in /home/user/my/path/
-	
+
 Options:
     -c\t\tClassic mode : goes back to the first directory named as the string
 	\t\tSet if default using (set -gx BD_OPT 'classic')
@@ -35,7 +35,7 @@ Options:
     -s\t\tSeems mode : goes back to the first directory containing string
     \t\tSet it as default using (set -gx BD_OPT 'sensitive')
     -i\t\tCase insensitive move (implies seems mode)
-    \t\tSet it as default using (set -gx BD_OPT 'insensitive')    
+    \t\tSet it as default using (set -gx BD_OPT 'insensitive')
     --help\t\tDisplay this help text
 
     Option must be unique and the first argument due to shell limitation.
@@ -104,7 +104,6 @@ function bd
         __bd_usage
         return 0
     case '*'
-		set __bd_opts "classic"
         set __bd_arg $argv[1]
     end
 
@@ -115,15 +114,15 @@ function bd
     case "insensitive"
         set __bd_newpwd (echo $__bd_oldpwd | sed 's|\(.*/'$__bd_arg'[^/]*/\).*|\1|I')
         set __bd_index  (echo $__bd_newpwd | awk '{ print index(tolower($0),tolower("/'$__bd_arg'")); }')
-    case 'classic'
+    case '*' # classic
         set __bd_newpwd (echo $__bd_oldpwd | sed 's|\(.*/'$__bd_arg'/\).*|\1|')
-        set __bd_index  (echo $__bd_newpwd | awk '{ print index($1,"/'$__bd_arg'/"); }')    
+        set __bd_index  (echo $__bd_newpwd | awk '{ print index($1,"/'$__bd_arg'/"); }')
     end
 
     if test $__bd_index = 0
         echo "No such occurence."
     end
-    
+
     echo "$__bd_newpwd"
     cd "$__bd_newpwd"
 


### PR DESCRIPTION
There was a bug where calling `bd string` would force it to `classic` ignoring the global setting of `BD_OPT`.
This fixes that, as well as a typo in the readme. The third commit removes trailing whitespace in the readme file (setting your editor to remove trailing whitespace automatically avoids this).