### PR TITLE
do cd .. if called without arguments

### DIFF
--- a/bd.fish
+++ b/bd.fish
@@ -52,9 +52,8 @@ function bd
 
     switch "$argv[1]"
     case "[1]"
-        echo "No argument."
-        __bd_usage
-        return 1
+        cd ..
+        return 0
     case "-s"
         if test "$argv[1]" = "$argv[-1]"
             echo "No argument."


### PR DESCRIPTION
Since this is a convenience function for an interactive shell, it makes more sense to me to make `bd` without arguments call `cd ..` rather than give an error message. I personally make an alias called `up` for bd.