### PR TITLE
Remove -n option from getopt arguments

### DIFF
--- a/bd.fish
+++ b/bd.fish
@@ -48,7 +48,7 @@ function bd
 	set -l __bd_arg
 	set -l __bd_opts $BD_OPT
 
-	set args (getopt -u -n fish-bd -l help -- "csi" $argv | sed 's/^ //g; s/ /\n/g')
+	set args (getopt -u fish-bd -l help -- "csi" $argv | sed 's/^ //g; s/ /\n/g')
 
 	set -l i 1
 	for arg in $args


### PR DESCRIPTION
On OSX, I was getting the following error every time I ran the bd command:

`getopt: illegal option -- n`

So, I've removed this option from the getopt call in the bd.fish file.