### PR TITLE
Use Fisher 4.0 uninstall event

### DIFF
--- a/conf.d/bd.fish
+++ b/conf.d/bd.fish
@@ -5,4 +5,6 @@
 # https://github.com/0rax/bd-fish
 #
 
-functions -e __bd_usage
+function _bd_uninstall --on-event bd_uninstall
+	functions -e __bd_usage
+end


### PR DESCRIPTION
`uninstall.fish` is no longer supported by Fisher 4.0 -- instead, make use of lifecycle events.

https://github.com/jorgebucaran/fisher/releases/tag/4.0.0